### PR TITLE
feat: Add option to grab `systemd`'s `XAUTHORITY` value

### DIFF
--- a/host-run
+++ b/host-run
@@ -108,6 +108,16 @@ if [ -n "$GAMESCOPE_WAYLAND_DISPLAY" ]; then
     "$@"
 fi
 
+# If requested by the user, grab the value of `XAUTHORITY` directly from `systemd`
+if [ -n "GRAB_SYSTEMD_USER_XAUTHORITY" ]; then
+  # Use `sh` to source the environment variables and dump `XAUTHORITY`
+  XAUTHORITY="$(flatpak-spawn --directory="$HOME" --host -- systemctl --user show-environment | \
+                cat - <(echo 'echo "$XAUTHORITY"') | sh)"
+  set -- \
+    --env=XAUTHORITY="$XAUTHORITY" \
+    "$@"
+fi
+
 # Finalize flatpak-spawn command
 set -- \
   flatpak-spawn \


### PR DESCRIPTION
This feature can be enabled by setting `GRAB_SYSTEMD_USER_XAUTHORITY` for the Wheel Wizard Flatpak.