### PR TITLE
Revert "build: Publish a single file with compression"

### DIFF
--- a/io.github.TeamWheelWizard.WheelWizard.yaml
+++ b/io.github.TeamWheelWizard.WheelWizard.yaml
@@ -55,19 +55,9 @@ modules:
           - exec host-run flatpak "$@"
         dest-filename: flatpak
     build-commands:
-      - |
-          dotnet publish \
-            WheelWizard/WheelWizard.csproj \
-            -c Release \
-            --source ./nuget-sources \
-            --source /usr/lib/sdk/dotnet8/nuget/packages \
-            /p:PublishSingleFile=true \
-            /p:IncludeAllContentForSelfExtract=true \
-            /p:IncludeNativeLibrariesForSelfExtract=true \
-            /p:EnableCompressionInSingleFile=true \
-            --self-contained true
+      - dotnet publish WheelWizard/WheelWizard.csproj -c Release --source ./nuget-sources --source /usr/lib/sdk/dotnet8/nuget/packages --self-contained true
       - mkdir -p ${FLATPAK_DEST}/bin
-      - cp -r --remove-destination WheelWizard/bin/Release/net*/$RUNTIME/publish/WheelWizard "${FLATPAK_DEST}/bin"
+      - cp -r --remove-destination WheelWizard/bin/Release/net*/$RUNTIME/publish/* "${FLATPAK_DEST}/bin"
       # Install custom host command wrapper
       - install -m0755 ./host-run "${FLATPAK_DEST}/bin/host-run"
       # Expose host `dolphin-emu` if available


### PR DESCRIPTION
Reverting because building a single file led to permission issues for users where the home directory in the Flatpak sandbox didn't have write permissions.